### PR TITLE
Add Jenkins pipeline for backend validation, tests, and frontend lint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,63 @@
+pipeline {
+    agent any
+
+    options {
+        timestamps()
+        ansiColor('xterm')
+    }
+
+    environment {
+        PIP_DISABLE_PIP_VERSION_CHECK = '1'
+        PYTHONDONTWRITEBYTECODE = '1'
+        PYTHONUNBUFFERED = '1'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Setup Backend') {
+            steps {
+                sh '''
+                    python3 -m pip install --upgrade pip
+                    python3 -m pip install poetry
+                    poetry install
+                '''
+            }
+        }
+
+        stage('Validate Workflows') {
+            steps {
+                sh 'poetry run validate-workflows'
+            }
+        }
+
+        stage('Backend Tests') {
+            steps {
+                sh '''
+                    export PYTHONPATH=backend
+                    poetry run pytest backend/tests/test_main.py backend/tests/test_metadata.py backend/tests/test_roadmap.py
+                '''
+            }
+        }
+
+        stage('Setup Frontend') {
+            steps {
+                dir('frontend') {
+                    sh 'npm ci'
+                }
+            }
+        }
+
+        stage('Frontend Lint') {
+            steps {
+                dir('frontend') {
+                    sh 'npm run lint'
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a CI pipeline to run repository-wide validation, backend tests, and frontend linting in Jenkins to keep checks consistent across builds.

### Description
- Add `Jenkinsfile` that defines a declarative pipeline with global options (`timestamps()`, `ansiColor('xterm')`) and environment hints for Python (`PIP_DISABLE_PIP_VERSION_CHECK`, `PYTHONDONTWRITEBYTECODE`, `PYTHONUNBUFFERED`).
- Implement stages to `checkout` the repo, set up the backend (install `pip`, `poetry`, and run `poetry install`), run `poetry run validate-workflows`, and execute targeted backend tests with `poetry run pytest` while exporting `PYTHONPATH=backend`.
- Add frontend setup and lint stages that run `npm ci` and `npm run lint` inside the `frontend` directory.

### Testing
- No automated tests were executed as part of this change because the patch only adds CI configuration that will be exercised by the Jenkins runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966b089604c8331bcac747c43ef13ca)